### PR TITLE
redirect to claims page after create

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -174,7 +174,7 @@ class ClaimsController < ApplicationController
   def create
     @claim = current_user.claims.build(claim_params)
     if @claim.save
-        redirect_to root_path
+        redirect_to claims_path
     else
         render 'new'
     end


### PR DESCRIPTION
Just changed the path from the root path of the website (root_path) to the path of claims (claims_path) after a new claim is created in the create function of the claims controller.